### PR TITLE
Allow BoxSynchronous upload and download with a null ProgressListener and a null Handler.

### DIFF
--- a/BoxAndroidLibrary/src/com/box/androidlib/FileTransfer/BoxFileDownload.java
+++ b/BoxAndroidLibrary/src/com/box/androidlib/FileTransfer/BoxFileDownload.java
@@ -229,7 +229,9 @@ public class BoxFileDownload {
                             mHandler.post(mOnProgressRunnable);
                         }
                     }
-                    mHandler.post(mOnProgressRunnable);
+                    if (mListener != null && mHandler != null) {
+                        mHandler.post(mOnProgressRunnable);
+                    }
                 }
                 for (int i = 0; i < destinationOutputStreams.length; i++) {
                     destinationOutputStreams[i].close();

--- a/BoxAndroidLibrary/src/com/box/androidlib/FileTransfer/BoxFileUpload.java
+++ b/BoxAndroidLibrary/src/com/box/androidlib/FileTransfer/BoxFileUpload.java
@@ -164,11 +164,11 @@ public class BoxFileUpload {
         }
         // Set up post body
         final HttpPost post = new HttpPost(builder.build().toString());
-        final MultipartEntityWithProgressListener reqEntity = new MultipartEntityWithProgressListener(HttpMultipartMode.BROWSER_COMPATIBLE, null,
-            Charset.forName(HTTP.UTF_8));
+        final MultipartEntity reqEntity;
 
         if (mListener != null && mHandler != null) {
-            reqEntity.setProgressListener(new MultipartEntityWithProgressListener.ProgressListener() {
+            reqEntity = new MultipartEntityWithProgressListener(HttpMultipartMode.BROWSER_COMPATIBLE, null, Charset.forName(HTTP.UTF_8));
+            ((MultipartEntityWithProgressListener)reqEntity).setProgressListener(new MultipartEntityWithProgressListener.ProgressListener() {
 
                 @Override
                 public void onTransferred(final long bytesTransferredCumulative) {
@@ -181,6 +181,8 @@ public class BoxFileUpload {
                     });
                 }
             });
+        } else {
+            reqEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE, null, Charset.forName(HTTP.UTF_8));
         }
 
         reqEntity.addPart("file_name", new InputStreamBody(sourceInputStream, filename) {


### PR DESCRIPTION
Utilizing BoxSynchronous should not require a ProgressListener or a Handler when calling upload or download.
